### PR TITLE
Replace static by hpc-dynamic paths from private repo

### DIFF
--- a/src/weathergen/datasets/data_reader_anemoi.py
+++ b/src/weathergen/datasets/data_reader_anemoi.py
@@ -230,8 +230,10 @@ class DataReaderAnemoi(DataReaderTimestep):
         channels = self.stream_info.get(ch_type)
         channels_exclude = self.stream_info.get(ch_type + "_exclude", [])
         # sanity check
-        not_empty = len(channels) > 0 if channels is not None else True
-        assert not_empty, "channels are empty; at least one channels must be present."
+        is_empty = len(channels) == 0 if channels is not None else False
+        if is_empty:
+            stream_name = self.stream_info["name"]
+            _logger.warning(f"No channel for {stream_name} for {ch_type}.")
 
         chs_idx = np.sort(
             [

--- a/src/weathergen/datasets/data_reader_base.py
+++ b/src/weathergen/datasets/data_reader_base.py
@@ -237,7 +237,6 @@ def check_reader_data(rdata: ReaderData, dtr: DTRange) -> None:
     )
     assert rdata.geoinfos.ndim == 2, f"geoinfos must be 2D, got {rdata.geoinfos.shape}"
     assert rdata.data.ndim == 2, f"data must be 2D {rdata.data.shape}"
-    assert rdata.data.shape[1] > 0, f"data must have at least one channel {rdata.data.shape}"
     assert rdata.datetimes.ndim == 1, f"datetimes must be 1D {rdata.datetimes.shape}"
 
     assert rdata.coords.shape[0] == rdata.data.shape[0], "coords and data must have same length"

--- a/src/weathergen/datasets/data_reader_base.py
+++ b/src/weathergen/datasets/data_reader_base.py
@@ -254,11 +254,9 @@ def check_reader_data(rdata: ReaderData, dtr: DTRange) -> None:
         f"{rdata.datetimes.shape[0]}"
     )
 
-    assert np.logical_and(
-        rdata.datetimes >= dtr.start,
-        # rdata.datetimes < dtr.end  # TODO: enforce monotonicty also for obs
-        rdata.datetimes <= dtr.end,
-    ).all(), f"datetimes for data points violate window {dtr}."
+    assert np.logical_and(rdata.datetimes >= dtr.start, rdata.datetimes < dtr.end).all(), (
+        f"datetimes for data points violate window {dtr}."
+    )
 
 
 class DataReaderBase(metaclass=ABCMeta):

--- a/src/weathergen/datasets/data_reader_obs.py
+++ b/src/weathergen/datasets/data_reader_obs.py
@@ -225,7 +225,7 @@ class DataReaderObs(DataReaderBase):
                 num_data_fields=len(channels_idx), num_geo_fields=len(self.geoinfo_idx)
             )
 
-        start_row = self.indices_start[idx]
+        start_row = self.indices_start[idx - 1]
         end_row = self.indices_end[idx]
 
         coords = self.data.oindex[start_row:end_row, self.coords_idx]
@@ -238,11 +238,17 @@ class DataReaderObs(DataReaderBase):
         data = self.data.oindex[start_row:end_row, channels_idx]
         datetimes = self.dt[start_row:end_row][:, 0]
 
+        # indices_start, indices_end above work with [t_start, t_end] and violate
+        # our convention [t_start, t_end) where endpoint is excluded
+        # compute mask to enforce it
+        t_win = self.time_window_handler.window(idx)
+        t_mask = np.logical_and(datetimes >= t_win.start, datetimes < t_win.end)
+
         rdata = ReaderData(
-            coords=coords,
-            geoinfos=geoinfos,
-            data=data,
-            datetimes=datetimes,
+            coords=coords[t_mask],
+            geoinfos=geoinfos[t_mask],
+            data=data[t_mask],
+            datetimes=datetimes[t_mask],
         )
 
         dtr = self.time_window_handler.window(idx)

--- a/src/weathergen/model/attention.py
+++ b/src/weathergen/model/attention.py
@@ -16,9 +16,7 @@ from torch.nn.attention.flex_attention import create_block_mask, flex_attention
 from weathergen.model.norms import AdaLayerNorm, RMSNorm
 
 
-####################################################################################################
 class MultiSelfAttentionHeadVarlen(torch.nn.Module):
-    #########################################
     def __init__(
         self,
         dim_embed,
@@ -39,8 +37,8 @@ class MultiSelfAttentionHeadVarlen(torch.nn.Module):
         self.num_heads = num_heads
         self.dropout_rate = dropout_rate
         self.with_flash = with_flash
-        self.with_residual = with_residual
         self.softcap = softcap
+        self.with_residual = with_residual
 
         assert dim_embed % num_heads == 0
         self.dim_head_proj = dim_embed // num_heads if dim_head_proj is None else dim_head_proj
@@ -52,6 +50,8 @@ class MultiSelfAttentionHeadVarlen(torch.nn.Module):
 
         if dim_aux is not None:
             self.lnorm = AdaLayerNorm(dim_embed, dim_aux, norm_eps=norm_eps)
+        else:
+            self.lnorm = norm(dim_embed, eps=norm_eps)
         self.proj_heads_q = torch.nn.Linear(dim_embed, num_heads * self.dim_head_proj, bias=False)
         self.proj_heads_k = torch.nn.Linear(dim_embed, num_heads * self.dim_head_proj, bias=False)
         self.proj_heads_v = torch.nn.Linear(dim_embed, num_heads * self.dim_head_proj, bias=False)
@@ -68,13 +68,13 @@ class MultiSelfAttentionHeadVarlen(torch.nn.Module):
 
         assert with_flash, "Only flash attention supported at the moment"
 
-    #########################################
     def forward(self, x, x_lens, ada_ln_aux=None):
-        x_in = x
-        x = x if ada_ln_aux is None else self.lnorm(x, ada_ln_aux)
+        if self.with_residual:
+            x_in = x
+        x = self.lnorm(x) if ada_ln_aux is None else self.lnorm(x, ada_ln_aux)
 
-        ## project onto heads and q,k,v and
-        #  ensure these are 4D tensors as required for flash attention
+        # project onto heads and q,k,v and
+        # ensure these are 4D tensors as required for flash attention
         s = [x.shape[0], self.num_heads, -1]
         qs = self.lnorm_q(self.proj_heads_q(x).reshape(s)).to(self.dtype)
         ks = self.lnorm_k(self.proj_heads_k(x).reshape(s)).to(self.dtype)
@@ -94,17 +94,14 @@ class MultiSelfAttentionHeadVarlen(torch.nn.Module):
             dropout_p=self.dropout_rate,
         )
 
-        x = self.proj_out(outs.flatten(-2, -1))
-
+        out = self.proj_out(outs.flatten(-2, -1))
         if self.with_residual:
-            x = x_in + x
+            out = out + x_in
 
-        return x
+        return out
 
 
-####################################################################################################
 class MultiSelfAttentionHeadVarlenFlex(torch.nn.Module):
-    #########################################
     def __init__(
         self,
         dim_embed,
@@ -124,6 +121,7 @@ class MultiSelfAttentionHeadVarlenFlex(torch.nn.Module):
         self.num_heads = num_heads
         self.with_flash = with_flash
         self.softcap = softcap
+        self.with_residual = with_residual
 
         assert dim_embed % num_heads == 0
         self.dim_head_proj = dim_embed // num_heads if dim_head_proj is None else dim_head_proj
@@ -151,20 +149,19 @@ class MultiSelfAttentionHeadVarlenFlex(torch.nn.Module):
 
         def att(qs, ks, vs, x_mask):
             def sparsity_mask(score, b, h, q_idx, kv_idx):
-                # return x_mask[q_idx] == x_mask[kv_idx]
                 return (q_idx // 16) == (kv_idx % 16)
 
             return flex_attention(qs, ks, vs, score_mod=sparsity_mask)
 
         self.compiled_flex_attention = torch.compile(att, dynamic=False)
 
-    #########################################
     def forward(self, x, x_lens=None):
-        x_in = x
+        if self.with_residual:
+            x_in = x
         x = self.lnorm(x)
 
-        ## project onto heads and q,k,v and
-        #  ensure these are 4D tensors as required for flash attention
+        # project onto heads and q,k,v and
+        # ensure these are 4D tensors as required for flash attention
         s = [x.shape[0], 1, self.num_heads, -1]
         qs = self.lnorm_q(self.proj_heads_q(x).reshape(s)).to(self.dtype).permute([1, 2, 0, 3])
         ks = self.lnorm_k(self.proj_heads_k(x).reshape(s)).to(self.dtype).permute([1, 2, 0, 3])
@@ -172,16 +169,14 @@ class MultiSelfAttentionHeadVarlenFlex(torch.nn.Module):
 
         outs = self.compiled_flex_attention(qs, ks, vs).transpose(1, 2).squeeze()
 
-        x = self.proj_out(outs.flatten(-2, -1))
+        out = self.dropout(self.proj_out(outs.flatten(-2, -1)))
         if self.with_residual:
-            x = x_in + x
+            out = out + x_in
 
-        return x
+        return out
 
 
-####################################################################################################
 class MultiSelfAttentionHeadLocal(torch.nn.Module):
-    #########################################
     def __init__(
         self,
         dim_embed,
@@ -190,6 +185,7 @@ class MultiSelfAttentionHeadLocal(torch.nn.Module):
         block_factor,
         dim_head_proj=None,
         dropout_rate=0.0,
+        with_residual=True,
         with_qk_lnorm=True,
         with_flash=True,
         norm_type="LayerNorm",
@@ -203,6 +199,7 @@ class MultiSelfAttentionHeadLocal(torch.nn.Module):
         self.num_heads = num_heads
         self.with_flash = with_flash
         self.softcap = softcap
+        self.with_residual = with_residual
 
         assert dim_embed % num_heads == 0
         self.dim_head_proj = dim_embed // num_heads if dim_head_proj is None else dim_head_proj
@@ -241,9 +238,9 @@ class MultiSelfAttentionHeadLocal(torch.nn.Module):
         # compile for efficiency
         self.flex_attention = torch.compile(flex_attention, dynamic=False)
 
-    #########################################
     def forward(self, x, ada_ln_aux=None):
-        x_in = x
+        if self.with_residual:
+            x_in = x
         x = self.lnorm(x) if ada_ln_aux is None else self.lnorm(x, ada_ln_aux)
 
         # project onto heads
@@ -254,12 +251,14 @@ class MultiSelfAttentionHeadLocal(torch.nn.Module):
 
         outs = self.flex_attention(qs, ks, vs, block_mask=self.block_mask).transpose(1, 2)
 
-        return x_in + self.proj_out(self.dropout(outs.flatten(-2, -1)))
+        out = self.proj_out(self.dropout(outs.flatten(-2, -1)))
+        if self.with_residual:
+            out = x_in + out
+
+        return out
 
 
-####################################################################################################
 class MultiCrossAttentionHeadVarlen(torch.nn.Module):
-    #########################################
     def __init__(
         self,
         dim_embed_q,
@@ -293,6 +292,9 @@ class MultiCrossAttentionHeadVarlen(torch.nn.Module):
 
         if dim_aux is not None:
             self.lnorm_in_q = AdaLayerNorm(dim_embed_q, dim_aux, norm_eps=norm_eps)
+        else:
+            self.lnorm_in_q = norm(dim_embed_q, eps=norm_eps)
+        self.lnorm_in_kv = norm(dim_embed_kv, eps=norm_eps)
 
         self.proj_heads_q = torch.nn.Linear(dim_embed_q, num_heads * self.dim_head_proj, bias=False)
         self.proj_heads_k = torch.nn.Linear(
@@ -310,20 +312,18 @@ class MultiCrossAttentionHeadVarlen(torch.nn.Module):
         lnorm = norm if with_qk_lnorm else torch.nn.Identity
         self.lnorm_q = lnorm(self.dim_head_proj, eps=norm_eps)
         self.lnorm_k = lnorm(self.dim_head_proj, eps=norm_eps)
-        self.lnorm_kv = lnorm(dim_embed_kv, eps=norm_eps)
 
         self.dtype = attention_dtype
         assert with_flash, "Only flash attention supported at the moment"
 
-    #########################################
-    def forward(self, x_q, x_kv, x_lens=None, x_kv_lens=None, ada_ln_aux=None):
+    def forward(self, x_q, x_kv, x_q_lens=None, x_kv_lens=None, ada_ln_aux=None):
         if self.with_residual:
             x_q_in = x_q
-        x_q = x_q if ada_ln_aux is None else self.lnorm_in_q(x_q, ada_ln_aux)
-        x_kv = self.lnorm_kv(x_kv)
+        x_q = self.lnorm_in_q(x_q) if ada_ln_aux is None else self.lnorm_in_q(x_q, ada_ln_aux)
+        x_kv = self.lnorm_in_kv(x_kv)
 
-        ## project onto heads and q,k,v and
-        #  ensure these are 4D tensors as required for flash attention
+        # project onto heads and q,k,v and
+        # ensure these are 4D tensors as required for flash attention
         s = [x_q.shape[0], self.num_heads, self.dim_head_proj]
         qs = self.lnorm_q(self.proj_heads_q(x_q).reshape(s)).to(self.dtype)
         s = [x_kv.shape[0], self.num_heads, self.dim_head_proj]
@@ -331,7 +331,7 @@ class MultiCrossAttentionHeadVarlen(torch.nn.Module):
         vs = self.proj_heads_v(x_kv).reshape(s)
 
         if x_kv_lens is not None:
-            cum_x_q_lens = torch.cumsum(x_lens, 0, dtype=torch.int32)
+            cum_x_q_lens = torch.cumsum(x_q_lens, 0, dtype=torch.int32)
             cum_x_kv_lens = torch.cumsum(x_kv_lens, 0, dtype=torch.int32)
             outs = flash_attn_varlen_func(
                 qs,
@@ -339,7 +339,7 @@ class MultiCrossAttentionHeadVarlen(torch.nn.Module):
                 vs,
                 cum_x_q_lens,
                 cum_x_kv_lens,
-                x_lens.max(),
+                x_q_lens.max(),
                 x_kv_lens.max(),
                 softcap=self.softcap,
                 dropout_p=self.dropout_rate,
@@ -347,26 +347,14 @@ class MultiCrossAttentionHeadVarlen(torch.nn.Module):
         else:
             assert False
 
-        # outs = self.dropout( self.proj_out( outs.flatten( -2, -1)) )
         outs = self.proj_out(outs.flatten(-2, -1))
         if self.with_residual:
             outs = x_q_in + outs
 
         return outs
 
-    #########################################
-    def attention(self, q, k, v):
-        scaling = 1.0 / torch.sqrt(torch.tensor(q.shape[-1]))
-        return torch.matmul(self.softmax(scaling * self.score(q, k)), v)
 
-    #########################################
-    def score(self, q, k):
-        return torch.matmul(q, torch.transpose(k, -2, -1))
-
-
-####################################################################################################
 class MultiCrossAttentionHeadVarlenSlicedQ(torch.nn.Module):
-    #########################################
     def __init__(
         self,
         dim_embed_q,
@@ -432,15 +420,14 @@ class MultiCrossAttentionHeadVarlenSlicedQ(torch.nn.Module):
         self.dtype = attention_dtype
         assert with_flash, "Only flash attention supported at the moment"
 
-    #########################################
     def forward(self, x_q, x_kv, x_q_lens=None, x_kv_lens=None, ada_ln_aux=None):
         if self.with_residual:
             x_q_in = x_q
         x_q = self.lnorm_in_q(x_q) if ada_ln_aux is None else self.lnorm_in_q(x_q, ada_ln_aux)
         x_kv = self.lnorm_in_kv(x_kv)
 
-        ## project onto heads and q,k,v and
-        #  ensure these are 4D tensors as required for flash attention
+        # project onto heads and q,k,v and
+        # ensure these are 4D tensors as required for flash attention
         s = [x_q.shape[0], self.num_heads, self.dim_head_proj]
         qs = [
             self.lnorm_q(head_proj(x_q_i).reshape(s)).to(self.dtype)
@@ -461,8 +448,8 @@ class MultiCrossAttentionHeadVarlenSlicedQ(torch.nn.Module):
                     vs,
                     cum_x_q_lens,
                     cum_x_kv_lens,
-                    x_q_lens.max().item(),
-                    x_kv_lens.max().item(),
+                    x_q_lens.max(),
+                    x_kv_lens.max(),
                     softcap=self.softcap,
                     dropout_p=self.dropout_rate,
                 )
@@ -475,17 +462,15 @@ class MultiCrossAttentionHeadVarlenSlicedQ(torch.nn.Module):
         return outs
 
 
-####################################################################################################
 class MultiSelfAttentionHead(torch.nn.Module):
-    #########################################
     def __init__(
         self,
         dim_embed,
         num_heads,
         dim_head_proj=None,
         dropout_rate=0.0,
-        with_qk_lnorm=True,
         with_residual=True,
+        with_qk_lnorm=True,
         with_flash=True,
         softcap=0.0,
         norm_type="LayerNorm",
@@ -497,11 +482,10 @@ class MultiSelfAttentionHead(torch.nn.Module):
 
         self.num_heads = num_heads
         self.with_flash = with_flash
+        self.softcap = softcap
         self.dropout_rate = dropout_rate
         self.with_residual = with_residual
-        self.softcap = softcap
 
-        assert with_flash, "You have to use flash attention"
         assert dim_embed % num_heads == 0
         self.dim_head_proj = dim_embed // num_heads if dim_head_proj is None else dim_head_proj
 
@@ -513,137 +497,49 @@ class MultiSelfAttentionHead(torch.nn.Module):
         if dim_aux is not None:
             self.lnorm = AdaLayerNorm(dim_embed, dim_aux, norm_eps=norm_eps)
         else:
-            self.lnorm = norm(dim_embed)
+            self.lnorm = norm(dim_embed, eps=norm_eps)
         self.proj_heads_q = torch.nn.Linear(dim_embed, num_heads * self.dim_head_proj, bias=False)
         self.proj_heads_k = torch.nn.Linear(dim_embed, num_heads * self.dim_head_proj, bias=False)
         self.proj_heads_v = torch.nn.Linear(dim_embed, num_heads * self.dim_head_proj, bias=False)
         self.proj_out = torch.nn.Linear(dim_embed, dim_embed, bias=False)
+        self.dropout = (
+            torch.nn.Dropout(p=dropout_rate) if dropout_rate > 0.0 else torch.nn.Identity()
+        )
 
         lnorm = norm if with_qk_lnorm else torch.nn.Identity
-        self.lnorm_q = lnorm(self.dim_head_proj)
-        self.lnorm_k = lnorm(self.dim_head_proj)
+        self.lnorm_q = lnorm(self.dim_head_proj, eps=norm_eps)
+        self.lnorm_k = lnorm(self.dim_head_proj, eps=norm_eps)
 
         self.dtype = attention_dtype
+        if with_flash:
+            self.att = torch.nn.functional.scaled_dot_product_attention
+        else:
+            self.att = self.attention
+            self.softmax = torch.nn.Softmax(dim=-1)
 
-    #########################################
     def forward(self, x, ada_ln_aux=None):
-        x_in = x
-        # x = self.lnorm(x) if ada_ln_aux is None else self.lnorm(x, ada_ln_aux)
+        if self.with_residual:
+            x_in = x
+        x = self.lnorm(x) if ada_ln_aux is None else self.lnorm(x, ada_ln_aux)
 
-        ## project onto heads and q,k,v and
-        #  ensure these are 4D tensors as required for flash attention
-        q_shape = [*([x.shape[0], 1] if len(x.shape) == 2 else x.shape[:-1]), self.num_heads, -1]
-        kv_shape = [
-            *([x.shape[0], 1] if len(x.shape) == 2 else x.shape[:-1]),
-            self.num_heads,
-            -1,
-        ]
-        qs = self.lnorm_q(self.proj_heads_q(x).reshape(q_shape)).to(self.dtype)
-        ks = self.lnorm_k(self.proj_heads_k(x).reshape(kv_shape)).to(self.dtype)
-        vs = self.proj_heads_v(x).reshape(kv_shape).to(self.dtype)
+        # project onto heads and q,k,v and
+        # ensure these are 4D tensors as required for flash attention
+        s = [*([x.shape[0], 1] if len(x.shape) == 2 else x.shape[:-1]), self.num_heads, -1]
+        qs = self.lnorm_q(self.proj_heads_q(x).reshape(s)).to(self.dtype)
+        ks = self.lnorm_k(self.proj_heads_k(x).reshape(s)).to(self.dtype)
+        vs = self.proj_heads_v(x).reshape(s).to(self.dtype)
 
         # ordering of tensors (seq, heads, embed) (which differs from torch's flash attention implt)
         outs = flash_attn_func(qs, ks, vs, softcap=self.softcap, dropout_p=self.dropout_rate)
 
+        out = self.proj_out(outs.flatten(-2, -1))
         if self.with_residual:
-            x = x_in + self.proj_out(outs.flatten(-2, -1))
-        else:
-            x = self.proj_out(outs.flatten(-2, -1))
+            out = out + x_in
 
-        return x
+        return out
 
 
-####################################################################################################
 class MultiCrossAttentionHead(torch.nn.Module):
-    #########################################
-    def __init__(
-        self,
-        dim_embed_q,
-        dim_embed_kv,
-        num_heads,
-        dim_head_proj=None,
-        dropout_rate=0.0,
-        with_qk_lnorm=True,
-        with_residual=True,
-        with_flash=True,
-        softcap=0.0,
-        norm_type="LayerNorm",
-        dim_aux=None,
-        norm_eps=1e-5,
-        attention_dtype=torch.bfloat16,
-    ):
-        super(MultiCrossAttentionHead, self).__init__()
-
-        self.num_heads = num_heads
-        self.with_flash = with_flash
-        self.dropout_rate = dropout_rate
-        self.with_residual = with_residual
-        self.softcap = softcap
-
-        assert with_flash, "You have to use flash attention"
-        assert dim_embed_kv % num_heads == 0
-        self.dim_head_proj_kv = (
-            dim_embed_kv // num_heads if dim_head_proj is None else dim_head_proj
-        )
-        self.dim_head_proj_q = dim_embed_q // num_heads if dim_head_proj is None else dim_head_proj
-
-        if norm_type == "LayerNorm":
-            norm = partial(torch.nn.LayerNorm, elementwise_affine=False, eps=norm_eps)
-        else:
-            norm = RMSNorm
-
-        if dim_aux is not None:
-            self.lnorm = AdaLayerNorm(dim_embed_kv, dim_aux, norm_eps=norm_eps)
-        else:
-            self.lnorm = norm(dim_embed_kv)
-        self.proj_heads_q = torch.nn.Linear(
-            dim_embed_q, num_heads * self.dim_head_proj_q, bias=False
-        )
-        self.proj_heads_k = torch.nn.Linear(
-            dim_embed_kv, num_heads * self.dim_head_proj_kv, bias=False
-        )
-        self.proj_heads_v = torch.nn.Linear(
-            dim_embed_kv, num_heads * self.dim_head_proj_kv, bias=False
-        )
-        self.proj_out = torch.nn.Linear(dim_embed_kv, dim_embed_kv, bias=False)
-
-        lnorm = norm if with_qk_lnorm else torch.nn.Identity
-        self.lnorm_q = lnorm(self.dim_head_proj_q)
-        self.lnorm_k = lnorm(self.dim_head_proj_kv)
-
-        self.dtype = attention_dtype
-
-    #########################################
-    def forward(self, q, x, ada_ln_aux=None):
-        x_in = x
-        # x = self.lnorm(x) if ada_ln_aux is None else self.lnorm(x, ada_ln_aux)
-
-        ## project onto heads and q,k,v and
-        #  ensure these are 4D tensors as required for flash attention
-        q_shape = [*([x.shape[0], 1] if len(x.shape) == 2 else x.shape[:-1]), self.num_heads, -1]
-        kv_shape = [
-            *([x.shape[0], 1] if len(x.shape) == 2 else x.shape[:-1]),
-            self.num_heads,
-            -1,
-        ]
-        qs = self.lnorm_q(self.proj_heads_q(x).reshape(q_shape)).to(self.dtype)
-        ks = self.lnorm_k(self.proj_heads_k(x).reshape(kv_shape)).to(self.dtype)
-        vs = self.proj_heads_v(x).reshape(kv_shape).to(self.dtype)
-
-        # ordering of tensors (seq, heads, embed) (which differs from torch's flash attention implt)
-        outs = flash_attn_func(qs, ks, vs, softcap=self.softcap, dropout_p=self.dropout_rate)
-
-        if self.with_residual:
-            x = x_in + self.proj_out(outs.flatten(-2, -1))
-        else:
-            x = self.proj_out(outs.flatten(-2, -1))
-
-        return x
-
-
-####################################################################################################
-class MultiCrossAttentionHeadSPDA(torch.nn.Module):
-    #########################################
     def __init__(
         self,
         dim_embed_q,
@@ -702,8 +598,8 @@ class MultiCrossAttentionHeadSPDA(torch.nn.Module):
             x_q_in = x_q
         x_q, x_kv = self.lnorm_in_q(x_q), self.lnorm_in_kv(x_kv)
 
-        ## project onto heads and q,k,v and
-        #  ensure these are 4D tensors as required for flash attention
+        # project onto heads and q,k,v and
+        # ensure these are 4D tensors as required for flash attention
         s = [x_q.shape[0], -1, self.num_heads, self.dim_head_proj]
         qs = self.lnorm_q(self.proj_heads_q(x_q).reshape(s)).to(self.dtype).transpose(-3, -2)
         s = [x_kv.shape[0], -1, self.num_heads, self.dim_head_proj]
@@ -719,12 +615,3 @@ class MultiCrossAttentionHeadSPDA(torch.nn.Module):
             outs = x_q_in + outs
 
         return outs
-
-    #########################################
-    def attention(self, q, k, v):
-        scaling = 1.0 / torch.sqrt(torch.tensor(q.shape[-1]))
-        return torch.matmul(self.softmax(scaling * self.score(q, k)), v)
-
-    #########################################
-    def score(self, q, k):
-        return torch.matmul(q, torch.transpose(k, -2, -1))

--- a/src/weathergen/model/blocks.py
+++ b/src/weathergen/model/blocks.py
@@ -16,6 +16,7 @@ from weathergen.model.attention import (
 )
 from weathergen.model.layers import MLP
 from weathergen.model.norms import AdaLayerNormLayer
+from weathergen.utils.config import get_dtype
 
 
 class SelfAttentionBlock(nn.Module):
@@ -199,22 +200,40 @@ class OriginalPredictionBlock(nn.Module):
         self.tr_mlp_hidden_factor = tr_mlp_hidden_factor
 
         self.block = nn.ModuleList()
+
         # Multi-Cross Attention Head
         self.block.append(
             MultiCrossAttentionHeadVarlen(
                 dim_in,
-                dim_kv,
-                num_heads,
+                self.cf.ae_global_dim_embed,
+                self.cf.streams[0]["target_readout"]["num_heads"],
                 dim_head_proj=self.tr_dim_head_proj,
                 with_residual=True,
-                **attention_kwargs,
+                with_qk_lnorm=True,
+                dropout_rate=0.1,  # Assuming dropout_rate is 0.1
+                with_flash=self.cf.with_flash_attention,
+                norm_type=attention_kwargs["norm_type"],
+                softcap=0.0,
+                dim_aux=dim_aux,
+                norm_eps=attention_kwargs["norm_eps"],
+                attention_dtype=get_dtype(self.cf.attention_dtype),
             )
         )
 
         # Optional Self-Attention Head
         if self.cf.pred_self_attention:
             self.block.append(
-                MultiSelfAttentionHeadVarlen(dim_in, num_heads=num_heads, **attention_kwargs)
+                MultiSelfAttentionHeadVarlen(
+                    dim_in,
+                    num_heads=self.cf.streams[0]["target_readout"]["num_heads"],
+                    dropout_rate=0.1,  # Assuming dropout_rate is 0.1
+                    with_qk_lnorm=True,
+                    with_flash=self.cf.with_flash_attention,
+                    norm_type=self.cf.norm_type,
+                    dim_aux=dim_aux,
+                    norm_eps=self.cf.norm_eps,
+                    attention_dtype=get_dtype(self.cf.attention_dtype),
+                )
             )
 
         # MLP Block
@@ -222,12 +241,12 @@ class OriginalPredictionBlock(nn.Module):
             MLP(
                 dim_in,
                 dim_out,
-                with_residual=(self.cf.pred_dyadic_dims or self.tro_type == "obs_value"),
+                with_residual=True,
                 hidden_factor=self.tr_mlp_hidden_factor,
                 dropout_rate=0.1,  # Assuming dropout_rate is 0.1
-                norm_type=attention_kwargs["norm_type"],
-                dim_aux=dim_aux,
-                norm_eps=mlp_norm_eps,
+                norm_type=self.cf.norm_type,
+                dim_aux=(dim_aux if self.cf.pred_mlp_adaln else None),
+                norm_eps=self.cf.mlp_norm_eps,
             )
         )
 

--- a/src/weathergen/model/engines.py
+++ b/src/weathergen/model/engines.py
@@ -12,6 +12,7 @@ import torch.nn as nn
 from torch.utils.checkpoint import checkpoint
 
 from weathergen.model.attention import (
+    MultiCrossAttentionHeadVarlen,
     MultiCrossAttentionHeadVarlenSlicedQ,
     MultiSelfAttentionHead,
     MultiSelfAttentionHeadLocal,
@@ -379,6 +380,112 @@ class EnsPredictionHead(torch.nn.Module):
         return preds
 
 
+class TargetPredictionEngineClassic(nn.Module):
+    def __init__(
+        self,
+        cf,
+        dims_embed,
+        dim_coord_in,
+        tr_dim_head_proj,
+        tr_mlp_hidden_factor,
+        softcap,
+        tro_type,
+    ):
+        """
+        Initialize the TargetPredictionEngine with the configuration.
+
+        :param cf: Configuration object containing parameters for the engine.
+        :param dims_embed: List of embedding dimensions for each layer.
+        :param dim_coord_in: Input dimension for coordinates.
+        :param tr_dim_head_proj: Dimension for head projection.
+        :param tr_mlp_hidden_factor: Hidden factor for the MLP layers.
+        :param softcap: Softcap value for the attention layers.
+        :param tro_type: Type of target readout (e.g., "obs_value").
+        """
+        super(TargetPredictionEngineClassic, self).__init__()
+
+        self.cf = cf
+        self.dims_embed = dims_embed
+        self.dim_coord_in = dim_coord_in
+        self.tr_dim_head_proj = tr_dim_head_proj
+        self.tr_mlp_hidden_factor = tr_mlp_hidden_factor
+        self.softcap = softcap
+        self.tro_type = tro_type
+        self.tte = torch.nn.ModuleList()
+
+        for i in range(len(self.dims_embed) - 1):
+            # Multi-Cross Attention Head
+            self.tte.append(
+                MultiCrossAttentionHeadVarlen(
+                    dim_embed_q=self.dims_embed[i],
+                    dim_embed_kv=self.cf.ae_global_dim_embed,
+                    num_heads=self.cf.streams[0]["target_readout"]["num_heads"],
+                    dim_head_proj=self.tr_dim_head_proj,
+                    with_residual=True,
+                    with_qk_lnorm=True,
+                    dropout_rate=0.1,  # Assuming dropout_rate is 0.1
+                    with_flash=self.cf.with_flash_attention,
+                    norm_type=self.cf.norm_type,
+                    softcap=self.softcap,
+                    dim_aux=self.dim_coord_in,
+                    norm_eps=self.cf.norm_eps,
+                    attention_dtype=get_dtype(self.cf.attention_dtype),
+                )
+            )
+
+            # Optional Self-Attention Head
+            if self.cf.pred_self_attention:
+                self.tte.append(
+                    MultiSelfAttentionHeadVarlen(
+                        dim_embed=self.dims_embed[i],
+                        num_heads=self.cf.streams[0]["target_readout"]["num_heads"],
+                        dropout_rate=0.1,  # Assuming dropout_rate is 0.1
+                        with_qk_lnorm=True,
+                        with_flash=self.cf.with_flash_attention,
+                        norm_type=self.cf.norm_type,
+                        dim_aux=self.dim_coord_in,
+                        norm_eps=self.cf.norm_eps,
+                        attention_dtype=get_dtype(self.cf.attention_dtype),
+                    )
+                )
+
+            # MLP Block
+            self.tte.append(
+                MLP(
+                    self.dims_embed[i],
+                    self.dims_embed[i + 1],
+                    with_residual=(self.cf.pred_dyadic_dims or self.tro_type == "obs_value"),
+                    hidden_factor=self.tr_mlp_hidden_factor,
+                    dropout_rate=0.1,  # Assuming dropout_rate is 0.1
+                    norm_type=self.cf.norm_type,
+                    dim_aux=(self.dim_coord_in if self.cf.pred_mlp_adaln else None),
+                    norm_eps=self.cf.mlp_norm_eps,
+                )
+            )
+
+    def forward(self, latent, output, latent_lens, output_lens, coordinates):
+        tc_tokens = output
+        tcs_lens = output_lens
+        tokens_stream = latent
+        tokens_lens = latent_lens
+        tcs_aux = coordinates
+
+        for ib, block in enumerate(self.tte):
+            if self.cf.pred_self_attention and ib % 3 == 1:
+                tc_tokens = checkpoint(block, tc_tokens, tcs_lens, tcs_aux, use_reentrant=False)
+            else:
+                tc_tokens = checkpoint(
+                    block,
+                    tc_tokens,
+                    tokens_stream,
+                    tcs_lens,
+                    tokens_lens,
+                    tcs_aux,
+                    use_reentrant=False,
+                )
+        return tc_tokens
+
+
 class TargetPredictionEngine(nn.Module):
     def __init__(
         self,
@@ -445,6 +552,7 @@ class TargetPredictionEngine(nn.Module):
         self.dropout = nn.Dropout(0.2)
         self.pos_embed = nn.Parameter(torch.zeros(1, 9, self.cf.ae_global_dim_embed))
         dim_aux = self.cf.ae_global_dim_embed
+
         for ith, dim in enumerate(self.dims_embed[:-1]):
             if self.cf.decoder_type == "PerceiverIO":
                 # a single cross attention layer as per https://arxiv.org/pdf/2107.14795
@@ -541,7 +649,7 @@ class TargetPredictionEngine(nn.Module):
                 output = checkpoint(
                     layer,
                     x=output,
-                    x_kv=(latent).flatten(0, 1),
+                    x_kv=latent.flatten(0, 1),
                     x_lens=output_lens,
                     aux=latent[:, 0],
                     x_kv_lens=latent_lens,

--- a/src/weathergen/model/model.py
+++ b/src/weathergen/model/model.py
@@ -344,6 +344,10 @@ class Model(torch.nn.Module):
             self.target_token_engines.append(tte)
 
             # ensemble prediction heads to provide probabilistic prediction
+            final_activation = si["pred_head"].get("final_activation", "Identity")
+            logger.debug(
+                f"{final_activation} activation as prediction head output of {si['name']} stream"
+            )
             self.pred_heads.append(
                 EnsPredictionHead(
                     dims_embed[-1],
@@ -351,6 +355,7 @@ class Model(torch.nn.Module):
                     si["pred_head"]["num_layers"],
                     si["pred_head"]["ens_size"],
                     norm_type=cf.norm_type,
+                    final_activation=final_activation,
                 )
             )
 

--- a/src/weathergen/model/utils.py
+++ b/src/weathergen/model/utils.py
@@ -8,6 +8,7 @@
 # nor does it submit to any jurisdiction.
 
 import torch
+import torch.nn as nn
 
 
 #########################################
@@ -20,3 +21,32 @@ def get_num_parameters(block):
 def freeze_weights(block):
     for p in block.parameters():
         p.requires_grad = False
+
+
+#########################################
+class ActivationFactory:
+    _registry = {
+        "identity": nn.Identity,
+        "tanh": nn.Tanh,
+        "softmax": nn.Softmax,
+        "sigmoid": nn.Sigmoid,
+        "gelu": nn.GELU,
+        "relu": nn.ReLU,
+        "leakyrelu": nn.LeakyReLU,
+        "elu": nn.ELU,
+        "selu": nn.SELU,
+        "prelu": nn.PReLU,
+        "softplus": nn.Softplus,
+        "linear": nn.Linear,
+        "logsoftmax": nn.LogSoftmax,
+        "silu": nn.SiLU,
+        "swish": nn.SiLU,
+    }
+
+    @classmethod
+    def get(cls, name: str, **kwargs):
+        name = name.lower()
+        if name not in cls._registry:
+            raise ValueError(f"Unsupported activation type: '{name}'")
+        fn = cls._registry[name]
+        return fn(**kwargs) if callable(fn) else fn

--- a/src/weathergen/run_train.py
+++ b/src/weathergen/run_train.py
@@ -11,6 +11,7 @@
 The entry point for training and inference weathergen-atmo
 """
 
+import logging
 import pdb
 import sys
 import time
@@ -38,8 +39,6 @@ def inference_from_args(argl: list[str]):
     parser = cli.get_inference_parser()
     args = parser.parse_args(argl)
 
-    init_loggers()
-
     inference_overwrite = dict(
         shuffle=False,
         start_date_val=args.start_date,
@@ -59,6 +58,10 @@ def inference_from_args(argl: list[str]):
         cli_overwrite,
     )
     cf = config.set_run_id(cf, args.run_id, args.reuse_run_id)
+
+    init_loggers(
+        logging_level=logging.DEBUG, debug_output_streams=f"./logs/debug_log_{cf.run_id}.txt"
+    )
 
     cf.run_history += [(args.from_run_id, cf.istep)]
     cf = config.set_paths(cf)

--- a/src/weathergen/utils/config.py
+++ b/src/weathergen/utils/config.py
@@ -65,14 +65,16 @@ def load_model_config(run_id: str, epoch: int | None, model_path: str | None) ->
     Load a configuration file from a given run_id and epoch.
     If run_id is a full path, loads it from the full path.
     """
-
     if Path(run_id).exists():  # load from the full path if a full path is provided
         fname = Path(run_id)
         _logger.info(f"Loading config from provided full run_id path: {fname}")
     else:
-        path_models = Path(model_path)
-        fname = path_models / run_id / _get_model_config_file_name(run_id, epoch)
-
+        # Load private config here...
+        shared_model_path = Path(_load_private_conf(
+            private_home=Path(model_path) if model_path else None
+        ).get("path_shared_working_dir")) / "models"
+        fname = shared_model_path / run_id / _get_model_config_file_name(run_id, epoch)
+        
     _logger.info(f"Loading config from specified run_id and epoch: {fname}")
 
     with fname.open() as f:

--- a/src/weathergen/utils/plot_training.py
+++ b/src/weathergen/utils/plot_training.py
@@ -597,7 +597,7 @@ def plot_train(args=None):
     parser.add_argument(
         "-m",
         "--model_base_dir",
-        default="./models/",
+        default=None,
         type=Path,
         help="Base-directory where models are saved",
     )
@@ -648,7 +648,7 @@ def plot_train(args=None):
     # parse the command line arguments
     args = parser.parse_args(args)
 
-    model_base_dir = Path(args.model_base_dir)
+    model_base_dir = Path(args.model_base_dir) if args.model_base_dir else None
     out_dir = Path(args.output_dir)
     streams = list(args.streams)
     x_types_valid = ["step"]  # TODO: add "reltime" support when fix available

--- a/src/weathergen/utils/train_logger.py
+++ b/src/weathergen/utils/train_logger.py
@@ -184,12 +184,15 @@ class TrainLogger:
 
     #######################################
     @staticmethod
-    def read(run_id: str, model_path: str, epoch: int = -1) -> Metrics:
+    def read(run_id: str, model_path: str = None, epoch: int = -1) -> Metrics:
         """
         Read data for run_id
         """
-
-        cf = config.load_model_config(run_id, epoch, model_path)
+        # Load config from given model_path if provided, otherwise use path from private config
+        if model_path:
+            cf = config.load_model_config(run_id=run_id, epoch=epoch, model_path=model_path)
+        else:
+            cf = config.load_config(private_home=None, from_run_id=run_id, epoch=epoch)
         run_id = cf.run_id
 
         result_dir_base = Path(cf.run_path)

--- a/uv.lock
+++ b/uv.lock
@@ -2345,6 +2345,7 @@ dependencies = [
     { name = "torch", version = "2.6.0+cu124", source = { registry = "https://download.pytorch.org/whl/cu124" }, marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "tqdm" },
     { name = "weathergen-common" },
+    { name = "weathergen-evaluate" },
     { name = "wheel" },
     { name = "zarr" },
 ]
@@ -2380,6 +2381,7 @@ requires-dist = [
     { name = "torch", marker = "sys_platform == 'macosx'", specifier = "==2.6.0", index = "https://download.pytorch.org/whl/cpu" },
     { name = "tqdm" },
     { name = "weathergen-common", editable = "packages/common" },
+    { name = "weathergen-evaluate", editable = "packages/evaluate" },
     { name = "wheel" },
     { name = "zarr", specifier = "~=2.17" },
 ]


### PR DESCRIPTION
## Description

Run, model, and result paths are always read from the private config, sucht that models can be transferred between HPCs and seamlessly fine-tuned and evaluated.

## Type of Change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number

Resolves #591

## Code Compatibility

-   [x] I have performed a self-review of my code

### Code Performance and Testing

-   [x] I ran the `uv run train` and (if necessary) `uv run evaluate` on a least one GPU node and it works 
-   [ ] If the new feature introduces modifications at the config level, I have made sure to have notified the other software developers through Mattermost and updated the paths in the `$WEATHER_GENERATOR_PRIVATE` directory
